### PR TITLE
Improve spacing of candidate name / grade

### DIFF
--- a/src/components/Candidates.js
+++ b/src/components/Candidates.js
@@ -52,7 +52,7 @@ const CandidateCard = ({
       display="flex"
       flexDirection="row"
       alignItems="center"
-      h="35px"
+      h="50px"
     >
       <Text fontWeight="bold" fontSize="12px" color="blue.800">View Profile</Text>
       <Icon ml="8px" color="blue.800" name="forward" />

--- a/src/components/Candidates.js
+++ b/src/components/Candidates.js
@@ -38,7 +38,7 @@ const CandidateCard = ({
         {' '}
         {last}
       </Text>
-      <Text fontWeight="bold" fontSize="12px" color="blueGray.500">
+      <Text fontWeight="bold" fontSize="12px" color="blueGray.500" w="50%" align="right">
         Grade
         {' '}
         {grade}

--- a/src/components/Candidates.js
+++ b/src/components/Candidates.js
@@ -29,7 +29,7 @@ const CandidateCard = ({
       alignItems="center"
       mx="14px"
       justifyContent="space-between"
-      h="35px"
+      h="50px"
       flexDirection="row"
       display="flex"
     >
@@ -52,7 +52,7 @@ const CandidateCard = ({
       display="flex"
       flexDirection="row"
       alignItems="center"
-      h="50px"
+      h="35px"
     >
       <Text fontWeight="bold" fontSize="12px" color="blue.800">View Profile</Text>
       <Icon ml="8px" color="blue.800" name="forward" />


### PR DESCRIPTION
This PR changes the styling of the candidate name and grade to make it look a bit less squished for longer names.

Before:
<img width="229" alt="Screen Shot 2022-05-25 at 8 54 34 PM" src="https://user-images.githubusercontent.com/29025984/170393076-64fc87e3-f23a-4196-99e2-3c22aeba45bc.png">

After:
<img width="225" alt="Screen Shot 2022-05-25 at 8 55 03 PM" src="https://user-images.githubusercontent.com/29025984/170393125-c5da5886-5fe1-4c73-b10e-b91d797369f8.png">

